### PR TITLE
Header hyperlink proposed change

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,7 +48,7 @@
          <a href="{{ site.baseurl }}/ProposedDataCenterOptimizationInitiativeMemo.pdf" class="button" style="color: white;">View PDF</a>
        </div>
       <h1>
-        <a href="/datacenters">{{ site.name }}</a>
+        <a href="{{ site.baseurl}}">{{ site.name }}</a>
       </h1>
     </header>
   </div>


### PR DESCRIPTION
The header is currently hyperlinked to datacenters.cio.gov/datacenters, which 404s. This pull request is to change that link to simply refresh the main page.
