### PR TITLE
Header link change

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,7 +48,7 @@
          <a href="{{ site.baseurl }}/ProposedDataCenterOptimizationInitiativeMemo.pdf" class="button" style="color: white;">View PDF</a>
        </div>
       <h1>
-        <a href="{{ site.baseurl}}">{{ site.name }}</a>
+        <a href="https://datacenters.cio.gov/">{{ site.name }}</a>
       </h1>
     </header>
   </div>


### PR DESCRIPTION
Changed header link to direct to main page https://datacenters.cio.gov/
